### PR TITLE
[WIP] Add baseConfig in execHttpPost

### DIFF
--- a/Example/FCLDemo/FCLDemo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/FCLDemo/FCLDemo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Sources/FCL/Config/FlowConfig.swift
+++ b/Sources/FCL/Config/FlowConfig.swift
@@ -24,6 +24,19 @@ public class Config {
         case domainTag = "fcl.appDomainTag"
     }
 
+    public func configLens(_ regex: String) -> [String: String] {
+        let matches = dict.filter { item in
+            item.key.range(of: regex, options: .regularExpression) != nil
+        }
+
+        let newDict = Dictionary(uniqueKeysWithValues:
+            matches.map { key, value in
+                (key.replacingOccurrences(of: regex, with: "", options: [.regularExpression]), value)
+            })
+
+        return newDict
+    }
+
     public func get(_ key: Key) -> String? {
         return dict[key.rawValue] ?? nil
     }

--- a/Sources/FCL/Extension/Codable.swift
+++ b/Sources/FCL/Extension/Codable.swift
@@ -1,0 +1,21 @@
+//
+//  File.swift
+//  
+//
+//  Created by Hao Fu on 17/2/22.
+//
+
+import Foundation
+
+extension Encodable {
+    /// Converting object to postable dictionary
+    func toDictionary(_ encoder: JSONEncoder = JSONEncoder()) throws -> [String: Any] {
+        let data = try encoder.encode(self)
+        let object = try JSONSerialization.jsonObject(with: data)
+        guard let json = object as? [String: Any] else {
+            let context = DecodingError.Context(codingPath: [], debugDescription: "Deserialized object is not a dictionary")
+            throw DecodingError.typeMismatch(type(of: object), context)
+        }
+        return json
+    }
+}

--- a/Sources/FCL/Extension/Codable.swift
+++ b/Sources/FCL/Extension/Codable.swift
@@ -1,6 +1,6 @@
 //
 //  File.swift
-//  
+//
 //
 //  Created by Hao Fu on 17/2/22.
 //

--- a/Sources/FCL/FCL.swift
+++ b/Sources/FCL/FCL.swift
@@ -16,6 +16,8 @@ public final class FCL: NSObject {
 
     private var session: ASWebAuthenticationSession?
 
+    public let version = "@outblock/fcl-swift@0.0.3"
+
     internal let api = API()
 
     @Published var currentUser: User?

--- a/Sources/FCL/Models/AuthnRequest.swift
+++ b/Sources/FCL/Models/AuthnRequest.swift
@@ -8,9 +8,17 @@
 import Foundation
 
 public struct BaseConfigRequest: Encodable {
-    var fclVersion: String = fcl.version
     var app: [String: String] = fcl.config.configLens("^app\\.detail\\.")
     var service: [String: String] = fcl.config.configLens("^service\\.")
+    var client = ClientInfo()
+}
+
+public struct ClientInfo: Encodable {
+    var fclVersion: String = fcl.version
+    var fclLibrary: URL = URL(string: "https://github.com/Outblock/fcl-swift")!
+    
+    @NullEncodable
+    var hostname: String? = nil
 }
 
 public struct AuthnRequest: Codable {

--- a/Sources/FCL/Models/AuthnRequest.swift
+++ b/Sources/FCL/Models/AuthnRequest.swift
@@ -7,6 +7,12 @@
 
 import Foundation
 
+public struct BaseConfigRequest: Encodable {
+    var fclVersion: String = fcl.version
+    var app: [String: String] = fcl.config.configLens("^app\\.detail\\.")
+    var service: [String: String] = fcl.config.configLens("^service\\.")
+}
+
 public struct AuthnRequest: Codable {
     let fType: String
     let fVsn: String

--- a/Sources/FCL/Network/FlowAPI.swift
+++ b/Sources/FCL/Network/FlowAPI.swift
@@ -57,18 +57,18 @@ final class API {
     func execHttpPost(url: URL, method: HTTPMethod = .post, params: [String: String]? = [:], data: Data? = nil) -> Future<AuthnResponse, Error> {
         return Future { promise in
 
-            var bodyWithConfigData: Data?
+            var configData: Data?
             if let baseConfig = try? BaseConfigRequest().toDictionary() {
                 var body: [String: Any]? = [:]
                 if let data = data {
-                    body = try? JSONSerialization.jsonObject(with: data ?? Data(), options: []) as? [String: Any]
+                    body = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
                 }
 
-                let bodyWithConfig = baseConfig.merging(body ?? [:]) { _, new in new }
-                bodyWithConfigData = try? JSONSerialization.data(withJSONObject: bodyWithConfig)
+                let configDict = baseConfig.merging(body ?? [:]) { _, new in new }
+                configData = try? JSONSerialization.data(withJSONObject: configDict)
             }
 
-            self.fetchService(url: url, method: method, params: params, data: bodyWithConfigData ?? data)
+            self.fetchService(url: url, method: method, params: params, data: configData ?? data)
                 .sink { completion in
                     if case let .failure(error) = completion {
                         print(error)

--- a/Sources/FCL/Send/FCLSend.swift
+++ b/Sources/FCL/Send/FCLSend.swift
@@ -47,7 +47,7 @@ public extension FCL {
                 newIX.message.cadence = script
             case let .limit(gasLimit):
                 newIX.message.computeLimit = gasLimit
-            case let .getAccount(_):
+            case let .getAccount:
                 newIX.tag = .getAccount
             case .getBlock:
                 newIX.tag = .getBlock

--- a/Tests/FCLTests.swift
+++ b/Tests/FCLTests.swift
@@ -23,6 +23,23 @@ final class FCLTests: XCTestCase {
         XCTAssertEqual(result2, result3)
     }
 
+    func testRegexInConfig() {
+        FCL.shared.config(appName: "FCLDemo",
+                          appIcon: "https://placekitten.com/g/200/200",
+                          location: "https://foo.com",
+                          walletNode: "https://fcl-http-post.vercel.app/api",
+                          accessNode: "https://access-testnet.onflow.org",
+                          env: "mainnet",
+                          scope: "email",
+                          authn: "")
+
+        let dict = fcl.config.configLens("^app\\.detail\\.")
+        XCTAssertNotNil(dict)
+        XCTAssertNotEqual(dict.keys.count, 0)
+        XCTAssertEqual(dict["icon"], "https://placekitten.com/g/200/200")
+        XCTAssertEqual(dict["title"], "FCLDemo")
+    }
+
     func testQuery() {
         let expectation = XCTestExpectation(description: "Query got executed!")
         fcl.query {


### PR DESCRIPTION
Add base config in each execService request, which will include `fclVersion` and `app` metadata. 
Need to follow up with the discussion in [here](https://github.com/onflow/fcl-js/issues/1029)

TODO:
- [x] Need to confirm about the base config body
- [ ] Better way to aggregate codable object
- [ ] Add custom config support

Related issue:
#4 
