### PR TITLE
Fixed visibility of currentUser in FCL

### DIFF
--- a/Sources/FCL/FCL.swift
+++ b/Sources/FCL/FCL.swift
@@ -20,7 +20,7 @@ public final class FCL: NSObject {
 
     internal let api = API()
 
-    @Published var currentUser: User?
+    @Published public var currentUser: User?
 
     private lazy var defaultAddressRegistry = AddressRegistry()
 


### PR DESCRIPTION
The _public_ modifier was missing so the var wasn't visible from outside.