### PR TITLE
Make User's address public for convenience, now that the User is also public (it's a @Published var)

### DIFF
--- a/Sources/FCL/CurrentUser/FlowUser.swift
+++ b/Sources/FCL/CurrentUser/FlowUser.swift
@@ -9,10 +9,11 @@ import Flow
 import Foundation
 
 public struct User: Decodable {
+    public let addr: Flow.Address
+    public private(set) var loggedIn: Bool = false
+    
     var fType: String = "USER"
     var fVsn: String = "1.0.0"
-    let addr: Flow.Address
-    var loggedIn: Bool = false
     var services: [Service]? = []
     //        let cid: String
     //        let expiresAt: Date


### PR DESCRIPTION
This way you can easily access the current logged in user's address, like: 

`        guard let currentUserAddress = fcl.currentUser?.addr else { return }
`