### PR TITLE
Provisional fix for current FCL version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,14 +16,12 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(name: "Flow",
-                 url: "https://github.com/outblock/flow-swift.git",
-                 from: "0.1.5"),
+        .package(url: "https://github.com/outblock/flow-swift.git", .exact("0.1.5")),
     ],
     targets: [
         .target(
             name: "FCL",
-            dependencies: ["Flow"],
+            dependencies: [.product(name: "Flow", package: "flow-swift")],
             path: "Sources/FCL"
         ),
         .testTarget(


### PR DESCRIPTION
With the latest flow-swift SDK update, compilation fails because some things are missing (NIO), so current users of the fcl version can't keep using it. With this fix, we lock the flow-swift dependency to the previous working version until the big FCL refactor is released. 