### PR TITLE
Dev wallet support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -87,7 +87,7 @@
         "repositoryURL": "https://github.com/WalletConnect/Web3.swift",
         "state": {
           "branch": null,
-          "revision": "bdaaed96eee3a9bf7f341165f89a94288961d14c",
+          "revision": "a628f094f8088ec72a95792de18eeea24b997462",
           "version": "1.0.0"
         }
       }

--- a/Sources/Models/AuthnRequest.swift
+++ b/Sources/Models/AuthnRequest.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Flow
 
 public struct BaseConfigRequest: Encodable {
     var app: [String: String] = fcl.config.configLens("^app\\.detail\\.")
@@ -14,6 +15,12 @@ public struct BaseConfigRequest: Encodable {
 
     var appIdentifier: String = fcl.config.get(.appId) ?? ""
     var accountProofNonce: String = fcl.config.get(.nonce) ?? ""
+    
+    var config = AppConfig()
+}
+
+public struct AppConfig: Encodable {
+    var app: [String: String] = fcl.config.configLens("^app\\.detail\\.")
 }
 
 public struct ClientInfo: Encodable {

--- a/Sources/Provider/Provider.swift
+++ b/Sources/Provider/Provider.swift
@@ -17,9 +17,10 @@ public extension FCL {
         case dapperSC
         case blocto
         case lilico
+        case devWallet
         case custom(FCL.WalletProvider)
 
-        public static var allCases: [FCL.Provider] = [.dapperSC, .lilico, .blocto]
+        public static var allCases: [FCL.Provider] = [.dapperSC, .lilico, .blocto, .devWallet]
 
         public static func getEnvCases(env: Flow.ChainID = fcl.currentEnv) -> [FCL.Provider] {
             allCases.filter { $0.supportNetwork.contains(env) }
@@ -37,6 +38,8 @@ public extension FCL {
                 return [.mainnet, .testnet]
             case .lilico:
                 return [.mainnet, .testnet]
+            case .devWallet:
+                return [.emulator]
             case let .custom(provider):
                 return provider.supportNetwork
             }
@@ -51,6 +54,8 @@ public extension FCL {
                     URL(string: "https://flow-wallet-testnet.blocto.app/api/flow/authn")!.absoluteString
             case .lilico:
                 return URL(string: "https://link.lilico.app")!.absoluteString
+            case .devWallet:
+                return URL(string: "http://127.0.0.1:8701/api/authn")!.absoluteString
             case let .custom(fclWalletProvider):
                 return fclWalletProvider.endpoint
             }
@@ -86,6 +91,13 @@ public extension FCL {
                              logo: URL(string: "https://raw.githubusercontent.com/Outblock/fcl-swift/main/Assets/lilico/logo.png")!,
                              method: .walletConnect,
                              endpoint: endpoint(chainId: chainId),
+                             supportNetwork: supportNetwork)
+            case .devWallet:
+                return .init(id: "devWallet",
+                             name: "Dev Wallet",
+                             logo: URL(string: "https://assets-global.website-files.com/5f734f4dbd95382f4fdfa0ea/6395e6749db8fe00a41cc279_flow-flow-logo.svg")!,
+                             method: .httpPost,
+                             endpoint: URL(string: "http://127.0.0.1:8701/api/authn")!.absoluteString,
                              supportNetwork: supportNetwork)
             case let .custom(provider):
                 return provider


### PR DESCRIPTION
Added support the fcl dev-wallet. Aside from adding a new case to the FCL.Provider enum, the dev wallet is also expecting the "app" field of an AuthnRequest to be wrapped in a "config" field as shown below from the dev-wallet source code.

```ts
export type ConnectedAppConfig = {
  type: string
  body: {
    appIdentifier?: string | undefined
    data: unknown
    extensions: unknown[]
    nonce?: string | undefined
  }
  service: Record<string, unknown>
  config: {
    services: {"OpenID.scopes": string}
    app: {
      icon: string
      title: string
    }
  }
}
```

I have modified the AuthnRequest to provide both parameters

```swift
public struct BaseConfigRequest: Encodable {
    var app: [String: String] = fcl.config.configLens("^app\\.detail\\.")
    var service: [String: String] = fcl.config.configLens("^service\\.")
    var client = ClientInfo()

    var appIdentifier: String = fcl.config.get(.appId) ?? ""
    var accountProofNonce: String = fcl.config.get(.nonce) ?? ""
    
    var config = AppConfig()
}

public struct AppConfig: Encodable {
    var app: [String: String] = fcl.config.configLens("^app\\.detail\\.")
}
```

In testing this has caused no issues with other wallets but I'm sure there is a "cleaner" way to handle this if you have any suggestions or changes.