### PR TITLE
Added function to retrieve account-proof

### DIFF
--- a/Sources/Config/FCLMetadata.swift
+++ b/Sources/Config/FCLMetadata.swift
@@ -35,8 +35,8 @@ public extension FCL {
         }
 
         public struct AccountProofConfig {
-            let appIdentifier: String
-            let nonce: String
+            public let appIdentifier: String
+            public let nonce: String
 
             public init(appIdentifier: String, nonce: String = fcl.generateNonce()) {
                 self.appIdentifier = appIdentifier

--- a/Sources/Method/AccountProof.swift
+++ b/Sources/Method/AccountProof.swift
@@ -9,6 +9,20 @@ import Flow
 import Foundation
 
 public extension FCL {
+    func getAccountProof() async throws -> FCLDataResponse {
+        guard let currentUser = currentUser, currentUser.loggedIn else {
+            throw Flow.FError.unauthenticated
+        }
+
+        guard let service = serviceOfType(services: currentUser.services, type: .accountProof),
+              let data = service.data
+        else {
+            throw FCLError.invaildService
+        }
+
+        return data
+    }
+    
     func verifyAccountProof(includeDomainTag: Bool = false) async throws -> Bool {
         guard let currentUser = currentUser, currentUser.loggedIn else {
             throw Flow.FError.unauthenticated

--- a/Sources/Models/FCLResponse.swift
+++ b/Sources/Models/FCLResponse.swift
@@ -223,7 +223,7 @@ extension FCL {
         }
     }
 
-    struct FCLDataResponse: Codable {
+    public struct FCLDataResponse: Codable {
         let fType: String
         let fVsn: String
         let nonce: String?


### PR DESCRIPTION
Added the `getAccountProof` function to retrieve and return the account-proof so it can be verified by an external service.